### PR TITLE
Use openssl on Void Linux

### DIFF
--- a/scripts/functions/requirements/void
+++ b/scripts/functions/requirements/void
@@ -20,7 +20,7 @@ requirements_void_define_base()
   requirements_check "$@" \
     autoconf automake bison ca-certificates curl \
     gdbm-devel glibc-devel gmp-devel \
-    libffi-devel libressl-devel libtool libyaml-devel \
+    libffi-devel openssl-devel libtool libyaml-devel \
     make ncurses-devel \
     patch pkg-config readline-devel \
     sqlite-devel zlib-devel


### PR DESCRIPTION
We require LibreSSL on Void Linux, but Void dropped Libre to return to OpenSSL last year:
https://voidlinux.org/news/2021/02/OpenSSL.html

Switching the dependency to OpenSSL.

Fixes # .

Changes proposed in this pull request:
*
*
*

Make sure that your pull request includes entry in the [CHANGELOG](CHANGELOG.md).